### PR TITLE
the arrow of 1-RTT Keys should be unidirectional

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -282,7 +282,7 @@ packet protection being called out specially.
 |            |<- Handshake Messages ->|            |
 |            |<---- 0-RTT Keys -------|            |
 |            |<--- Handshake Keys-----|            |
-|   QUIC     |<---- 1-RTT Keys ------>|    TLS     |
+|   QUIC     |<---- 1-RTT Keys -------|    TLS     |
 |            |<--- Handshake Done ----|            |
 +------------+                        +------------+
  |         ^


### PR DESCRIPTION
Going through the changes to the TLS document, I noticed one tiny issue. Hence the PR.